### PR TITLE
Correct dependency ID. Set sideness to SERVER. Include Minecraft depe…

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -12,9 +12,15 @@ version="${file.jarVersion}"
 displayName="QuickTeleports"
 description='''
 This mod adds a quick and easy way to send tp requests with /tpa and /tpaccept'''
-[[dependencies.quickhomes]]
+[[dependencies.quickteleports]]
     modId="forge"
     mandatory=true
     versionRange="[33.0.0,)"
     ordering="NONE"
-    side="BOTH" 
+    side="SERVER" 
+[[dependencies.quickteleports]]
+    modId="minecraft"
+    mandatory=true
+    versionRange="[1.16.2,)"
+    ordering="NONE"
+    side="SERVER" 


### PR DESCRIPTION
I noticed that your mods.toml is missing the dependency definition for Minecraft, as well as having smaller errors in the dependency definitions.

* Forge and Minecraft dependency definitions should always use the mods own ID in `[[dependency.id_here]]`
* You write in your README that this is a serverside mod, therefor `side=` has been set to `SERVER` for both Forge and Minecraft

mods.toml need to specify their sideness so Minecraft/Forge knows whether the mod needs to be available on the client, the server, or both. If a mod uses the modId for dependencies.<value_of_modId>, it also helps with ServerPackCreator identifying clientside-only mods. [Reference issue #70](https://github.com/Griefed/ServerPackCreator/issues/70) of ServerPackCreator.

Let me know what you think. 👋

Cheers,
Griefed